### PR TITLE
Implement code formatting for scala.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Supported features
 - Show compile errors and warnings as markers in the editors
 - Show all compile errors and warnings in a special tab and allow to cycle though it.
 - Outline
+- Code formatter (using scalariform)
 
 
 Installation
@@ -29,3 +30,5 @@ Installation
 References
 ----------
 - https://github.com/ensime/ensime-server
+- http://scala-ide.org/scalariform/
+- http://c9.io/

--- a/ensime.js
+++ b/ensime.js
@@ -2,7 +2,7 @@ define(function(require, exports, module) {
     main.consumes = [
         "Plugin", "language", "ui", "commands", "menus", "preferences",
         "settings", "notification.bubble", "installer", "save",
-        "Editor", "editors", "tabManager", "Datagrid"
+        "Editor", "editors", "tabManager", "Datagrid", "format"
     ];
     main.provides = ["ensime"];
     return main;
@@ -20,6 +20,7 @@ define(function(require, exports, module) {
         var save = imports.save;
         var editors = imports.editors;
         var tabManager = imports.tabManager;
+        var format = imports.format;
 
 
         /***** Initialization *****/
@@ -280,12 +281,37 @@ define(function(require, exports, module) {
                     handler.emit("refreshMarkers");
                 });
             });
+            language.registerLanguageHandler("plugins/c9.ide.language.scala/worker/scala_formatter", function(err, handler) {
+                if (err) return console.error(err);
+                setupConnectorBridge(handler);
+                format.addFormatter("Scala (Scalariform)", "scala", plugin);
+                format.on("format", function(e) {
+                    //TODO does not yet work due to a bug in worker.codeFormat
+                    // language.getWorker(function(err, worker) {
+                    // if (err) return console.error("Could not get language worker");
+                    // worker.emit("code_format", {
+                    // data: {}
+                    // });
+                    // });
+                    handler.emit("format");
+                    return true;
+                });
+                //TODO workaround for error in worker.codeFormat
+                handler.on("code_format", function(e) {
+                    var tab = tabManager.findTab(e.path);
+                    if (tab) {
+                        tab.document.value = e.value;
+                        tab.editor.ace.selection.clearSelection();
+                    }
+                });
+            });
         });
 
         plugin.on("unload", function() {
             ensimeConnector = null;
             ensimeRunning = false;
             ensimeReady = false;
+            language.unregisterLanguageHandler("plugins/c9.ide.language.scala/worker/scala_formatter");
             language.unregisterLanguageHandler("plugins/c9.ide.language.scala/worker/scala_completer");
             language.unregisterLanguageHandler("plugins/c9.ide.language.scala/worker/scala_outline");
             language.unregisterLanguageHandler("plugins/c9.ide.language.scala/worker/scala_markers");

--- a/worker/scala_formatter.js
+++ b/worker/scala_formatter.js
@@ -1,0 +1,57 @@
+define(function(require, exports, module) {
+
+  var baseHandler = require("plugins/c9.ide.language/base_handler");
+  var workerUtil = require("plugins/c9.ide.language/worker_util");
+  var util = require("./util");
+
+  var handler = module.exports = Object.create(baseHandler);
+  var emitter;
+
+  handler.handlesLanguage = function(language) {
+    return language === "scala";
+  };
+
+  handler.init = function(callback) {
+    emitter = handler.getEmitter();
+
+    //TODO Temporary, until the bug in worker.codeFormat is fixed.
+    emitter.on("format", function(editor) {
+      handler.codeFormat(handler.doc, function(err, value) {
+        if (err) return console.error("Formatting failed: " + err);
+        emitter.emit("code_format", {
+          path: handler.path,
+          value: value
+        });
+      });
+    });
+
+    if (!handler.workspaceDir) {
+      handler.workspaceDir = "/home/ubuntu/workspace";
+      console.warn("WorkspaceDir was undefined in the language handler - setting it to " + handler.workspaceDir);
+    }
+
+    console.log("Scala formatter initialized.");
+    callback();
+  };
+
+  function executeEnsime(req, callback) {
+    util.executeEnsime(emitter, req, callback);
+  }
+
+  handler.codeFormat = function(doc, callback) {
+    console.log("Code Format called for " + handler.path);
+    executeEnsime({
+      typehint: "FormatOneSourceReq",
+      file: {
+        file: handler.workspaceDir + handler.path,
+        currentContents: true
+      }
+    }, function(err, result) {
+      if (err) {
+        workerUtil.showError("Could not format the code");
+        return callback(err);
+      }
+      callback(false, result.text);
+    });
+  };
+});


### PR DESCRIPTION
The Code still contains a workaround because the c9-code in worker.codeFormat have a bug.

Fixes #14 